### PR TITLE
proper mentor icons, even smaller mode, job frames downscale, player statuses

### DIFF
--- a/PartyIcons/Api/XivApi.cs
+++ b/PartyIcons/Api/XivApi.cs
@@ -256,6 +256,25 @@ namespace PartyIcons.Api
                 Marshal.WriteInt16(iconXAdjustPtr, x);
                 Marshal.WriteInt16(iconYAdjustPtr, y);
             }
+
+            public void AdjustIconPosition(short x = 0, short y = 0)
+            {
+                if (x != 0)
+                {
+                    var iconXAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconXAdjust)).ToInt32();
+                    var val = Marshal.ReadInt16(iconXAdjustPtr);
+                    val += x;
+                    Marshal.WriteInt16(iconXAdjustPtr, val);
+                }
+
+                if (y != 0)
+                {
+                    var iconYAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconYAdjust)).ToInt32();
+                    var val = Marshal.ReadInt16(iconYAdjustPtr);
+                    val += y;
+                    Marshal.WriteInt16(iconYAdjustPtr, val);
+                }
+            }
         }
 
         public class SafeNamePlateInfo

--- a/PartyIcons/Configuration.cs
+++ b/PartyIcons/Configuration.cs
@@ -18,7 +18,8 @@ namespace PartyIcons
         public bool TestingMode              = true;
         public bool EasternNamingConvention  = false;
         public bool DisplayRoleInPartyList   = false;
-
+        public bool ShowPlayerStatus = true;
+        
         public IconSetId         IconSetId { get; set; } = IconSetId.GlowingColored;
         public NameplateSizeMode SizeMode  { get; set; } = NameplateSizeMode.Medium;
 

--- a/PartyIcons/PluginUI.cs
+++ b/PartyIcons/PluginUI.cs
@@ -176,6 +176,17 @@ namespace PartyIcons
             ImGui.Text("Hide own nameplate");
             ImGuiHelpTooltip("You can turn your own nameplate on and also turn this\nsetting own to only use nameplate to display own raid position.\nIf you don't want your position displayed with this setting you can simply disable\nyour nameplates in the Character settings.");
 
+            var showPlayerStatus = _configuration.ShowPlayerStatus;
+            if (ImGui.Checkbox("##showplayerstatus", ref showPlayerStatus))
+            {
+                _configuration.ShowPlayerStatus = showPlayerStatus;
+                _configuration.Save();
+            }
+
+            ImGui.SameLine();
+            ImGui.Text("Show player status");
+            ImGuiHelpTooltip("Display player status, or at least if it's a new adventurer or a mentor if possible");
+
             ImGui.Dummy(new Vector2(0f, 25f));
 
             var iconSetId = _configuration.IconSetId;

--- a/PartyIcons/Runtime/NameplateUpdater.cs
+++ b/PartyIcons/Runtime/NameplateUpdater.cs
@@ -112,10 +112,11 @@ namespace PartyIcons.Runtime
                 return _hook.Original(namePlateObjectPtr, isPrefixTitle, displayTitle, title, name, fcName, iconID);
             }
 
+            var oldIconId = iconID;
             _view.NameplateDataForPC(npObject, ref isPrefixTitle, ref displayTitle, ref title, ref name, ref fcName, ref iconID);
 
             var result = _hook.Original(namePlateObjectPtr, isPrefixTitle, displayTitle, title, name, fcName, iconID);
-            _view.SetupForPC(npObject);
+            _view.SetupForPC(npObject, oldIconId);
 
             if (originalName != name)
             {

--- a/PartyIcons/Utils/SeStringUtils.cs
+++ b/PartyIcons/Utils/SeStringUtils.cs
@@ -66,7 +66,7 @@ namespace PartyIcons.Utils
             return seString;
         }
 
-        public static SeString Icon(BitmapFontIcon icon, string prefix=null)
+        public static SeString Icon(BitmapFontIcon icon, string? prefix=null)
         {
             var seString = new SeString(new List<Payload>());
             if (prefix != null)

--- a/PartyIcons/View/NameplateSizeMode.cs
+++ b/PartyIcons/View/NameplateSizeMode.cs
@@ -5,5 +5,6 @@
         Smaller,
         Medium,
         Bigger,
+        Tiny
     }
 }

--- a/PartyIcons/View/NameplateView.cs
+++ b/PartyIcons/View/NameplateView.cs
@@ -240,14 +240,14 @@ namespace PartyIcons.View
 
                 case NameplateMode.SmallJobIcon:
                     name = GetStateNametext(_configuration.ShowPlayerStatus ? iconID : -1, _iconPrefix, SeStringUtils.SeStringFromPtr(name));
-                    iconID = GetClassIcon(npObject.NamePlateInfo, (_configuration.ShowPlayerStatus) ? iconID : -1);
+                    iconID = GetClassIcon(npObject.NamePlateInfo, _configuration.ShowPlayerStatus ? iconID : -1);
                     break;
 
                 case NameplateMode.BigJobIcon:
                     name = GetStateNametext(iconID);
                     fcName = SeStringUtils.emptyPtr;
                     displayTitle = false;
-                    iconID = GetClassIcon(npObject.NamePlateInfo);
+                    iconID = GetClassIcon(npObject.NamePlateInfo, _configuration.ShowPlayerStatus ? iconID : -1);
                     break;
 
                 case NameplateMode.BigJobIconAndPartySlot:
@@ -260,12 +260,12 @@ namespace PartyIcons.View
                         //var str = _stylesheet.GetPartySlotNumber(partySlot.Value, genericRole);
                         //str.Payloads.Insert(0, new TextPayload(_iconPrefix));
                         name = GetStateNametext(_configuration.ShowPlayerStatus ? iconID : -1, _iconPrefix, _stylesheet.GetPartySlotNumber(partySlot.Value, genericRole));
-                        iconID = GetClassIcon(npObject.NamePlateInfo);
+                        iconID = GetClassIcon(npObject.NamePlateInfo, _configuration.ShowPlayerStatus ? iconID : -1);
                     }
                     else
                     {
                         name = GetStateNametext(_configuration.ShowPlayerStatus ? iconID : -1);
-                        iconID = GetClassIcon(npObject.NamePlateInfo);
+                        iconID = GetClassIcon(npObject.NamePlateInfo, _configuration.ShowPlayerStatus ? iconID : -1);
                     }
                     break;
 

--- a/PartyIcons/View/NameplateView.cs
+++ b/PartyIcons/View/NameplateView.cs
@@ -28,7 +28,7 @@ namespace PartyIcons.View
 
         private readonly IconSet _iconSet;
         private const string _iconPrefix = "   ";
-        private readonly int[] nameables = { 061521, 061522, 061523, 061540, 061542, 061543, 061544, 061547 };
+        private readonly int[] ignorables = { 061521, 061522, 061523, 061540, 061542, 061543, 061544, 061547 };
 
         public NameplateMode PartyMode  { get; set; }
         public NameplateMode OthersMode { get; set; }
@@ -70,7 +70,7 @@ namespace PartyIcons.View
 
                     if (_configuration.IconSetId == IconSetId.Framed)
                     {
-                        if (oldIconId != -1 && !nameables.Contains(oldIconId))
+                        if (!IsIgnorableStatus(oldIconId))
                         {
                             SetupDefault(npObject);
                             npObject.AdjustIconPosition(10, 0);
@@ -174,7 +174,9 @@ namespace PartyIcons.View
                     break;
             }
 
-            if (GetModeForNameplate(npObject) < NameplateMode.RoleLetters && _configuration.IconSetId == IconSetId.Framed)
+            if (GetModeForNameplate(npObject) < NameplateMode.RoleLetters
+                && _configuration.IconSetId == IconSetId.Framed 
+                && (!_configuration.ShowPlayerStatus || IsIgnorableStatus(oldIconId)))
             {
                 iconScale *=  0.75f;
                 iconOffset.Y += 4;
@@ -257,8 +259,6 @@ namespace PartyIcons.View
                     if (partySlot != null)
                     {
                         var genericRole = JobExtensions.GetRole((Job)npObject.NamePlateInfo.GetJobID());
-                        //var str = _stylesheet.GetPartySlotNumber(partySlot.Value, genericRole);
-                        //str.Payloads.Insert(0, new TextPayload(_iconPrefix));
                         name = GetStateNametext(_configuration.ShowPlayerStatus ? iconID : -1, _iconPrefix, _stylesheet.GetPartySlotNumber(partySlot.Value, genericRole));
                         iconID = GetClassIcon(npObject.NamePlateInfo, _configuration.ShowPlayerStatus ? iconID : -1);
                     }
@@ -288,7 +288,7 @@ namespace PartyIcons.View
 
         private int GetClassIcon(XivApi.SafeNamePlateInfo info, int def = -1)
         {
-            if (def != -1 && !nameables.Contains(def))
+            if (def != -1 && !ignorables.Contains(def))
                 return def;
         	
             var genericRole = JobExtensions.GetRole((Job)info.GetJobID());
@@ -298,7 +298,7 @@ namespace PartyIcons.View
 
         private bool IsIgnorableStatus(int statusIcon)
         {
-            return statusIcon == -1 || nameables.Contains(statusIcon);
+            return statusIcon == -1 || ignorables.Contains(statusIcon);
         }
 
         private int GetClassRoleColoredIcon(XivApi.SafeNamePlateInfo info, RoleId roleId, int def = -1)

--- a/PartyIcons/View/NameplateView.cs
+++ b/PartyIcons/View/NameplateView.cs
@@ -63,6 +63,9 @@ namespace PartyIcons.View
             switch (GetModeForNameplate(npObject))
             {
                 case NameplateMode.Default:
+                    SetupDefault(npObject);
+                    return;
+
                 case NameplateMode.SmallJobIcon:
 
                     if (_configuration.IconSetId == IconSetId.Framed)
@@ -315,9 +318,9 @@ namespace PartyIcons.View
                 //061522 - party member
                 061523 => SeStringUtils.Icon(BitmapFontIcon.NewAdventurer, prefix),
                 061540 => SeStringUtils.Icon(BitmapFontIcon.Mentor, prefix),
-                061542 => SeStringUtils.Icon(BitmapFontIcon.MentorPvP, prefix),
+                061542 => SeStringUtils.Icon(BitmapFontIcon.MentorPvE, prefix),
                 061543 => SeStringUtils.Icon(BitmapFontIcon.MentorCrafting, prefix),
-                061544 => SeStringUtils.Icon(BitmapFontIcon.MentorPvE, prefix),
+                061544 => SeStringUtils.Icon(BitmapFontIcon.MentorPvP, prefix),
                 061547 => SeStringUtils.Icon(BitmapFontIcon.Returner, prefix),
                 _ => null
             };

--- a/PartyIcons/View/NameplateView.cs
+++ b/PartyIcons/View/NameplateView.cs
@@ -70,7 +70,7 @@ namespace PartyIcons.View
                         if (oldIconId != -1 && !nameables.Contains(oldIconId))
                         {
                             SetupDefault(npObject);
-                            npObject.AdjustIconPosition(12, 0);
+                            npObject.AdjustIconPosition(10, 0);
                             return;
                         }
                         npObject.SetIconScale(0.75f);
@@ -80,7 +80,7 @@ namespace PartyIcons.View
                     else
                     {
                         SetupDefault(npObject);
-                        npObject.AdjustIconPosition(12, 0);
+                        npObject.AdjustIconPosition(10, 0);
                     }
                     return;
 


### PR DESCRIPTION
- small mode is still bigger than normal size, so I've add a tiny mod that uses NORMAL size
- job frames are way too big, downscaled to normal icon size
- returners are not mentors, and mentors are different
- ability to display player statuses