### PR TITLE
Update to API v7 and use Dalamud.ContextMenu

### DIFF
--- a/PartyIcons/PartyIcons.csproj
+++ b/PartyIcons/PartyIcons.csproj
@@ -11,13 +11,14 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net5.0-windows</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <Platforms>x64</Platforms>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
     <ItemGroup>
@@ -44,6 +45,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Dalamud.ContextMenu" Version="1.2.1" />
         <PackageReference Include="DalamudPackager" Version="2.1.7" />
         <PackageReference Include="XivCommon" Version="5.0.0" />
         <Reference Include="FFXIVClientStructs">

--- a/PartyIcons/PartyIcons.json
+++ b/PartyIcons/PartyIcons.json
@@ -4,6 +4,7 @@
   "Punchline": "Replace names with job icons, raid role positions and more!",
   "Description": "Adjusts player nameplates base on current content. For example you can display raid positions (that are assigned automatically by listening to the chat), job icons, or names with job icons.\n\nReverse-engineering effort achived by authors of JobIcons: haplo, daemitus, Loskh, wozaiha, without them this plugin would not be possible!",
   "InternalName": "PartyIcons",
+  "DalamudApiLevel": 7,
   "RepoUrl": "https://github.com/shdwp/xivPartyIcons",
   "Tags": [
     "UI"


### PR DESCRIPTION
I updated the config for API v7 and .NET 6 so that it can build and run in the current client. I also ported the context menu commands to use Kalilistic's Dalamud.ContextMenu library.

Since context submenus are not supported by this library, here is what the context menu looks like now: 

![image](https://user-images.githubusercontent.com/99750849/186735398-d55fb70e-405c-4f87-bc20-2047a2ca6740.png)