### PR TITLE
add toggle to assignments from chat and remove hardcoded build path

### DIFF
--- a/PartyIcons/Configuration.cs
+++ b/PartyIcons/Configuration.cs
@@ -19,6 +19,7 @@ public class Configuration : IPluginConfiguration
     public bool EasternNamingConvention = false;
     public bool DisplayRoleInPartyList = false;
     public bool UseContextMenu = false;
+    public bool AssignFromChat = true;
 
     public IconSetId IconSetId { get; set; } = IconSetId.GlowingColored;
     public NameplateSizeMode SizeMode { get; set; } = NameplateSizeMode.Medium;

--- a/PartyIcons/PartyIcons.csproj
+++ b/PartyIcons/PartyIcons.csproj
@@ -7,7 +7,7 @@
         <Description>PartyIcons plugin</Description>
         <Copyright>shdwp 2021</Copyright>
         <PackageProjectUrl>https://github.com/shdwp/xivPartyIcons</PackageProjectUrl>
-        <Version>1.0.8.1</Version>
+        <Version>1.0.8.2</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -41,9 +41,6 @@
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-      <OutputPath>C:\Users\shdwp\AppData\Roaming\XIVLauncher\devPlugins\PartyIcons</OutputPath>
-    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Dalamud.ContextMenu" Version="1.2.1" />

--- a/PartyIcons/PluginUI.cs
+++ b/PartyIcons/PluginUI.cs
@@ -270,6 +270,18 @@ internal class PluginUI : IDisposable
         ImGui.Text("Add context menu commands to assign roles");
         ImGuiHelpTooltip("Adds context menu commands to assign roles to players. When applicable, commands to swap role and use a suggested role are also added.");
 
+        var assignFromChat = _configuration.AssignFromChat;
+
+        if (ImGui.Checkbox("##assignFromChat", ref assignFromChat))
+        {
+            _configuration.AssignFromChat = assignFromChat;
+            _configuration.Save();
+        }
+
+        ImGui.SameLine();
+        ImGui.Text("Allow party to self-assign role");
+        ImGuiHelpTooltip("Allows party members to assign themselves a role. i.e. saying 'h1' in party chat will give that player the healer 1 role.");
+
         DisplayNotice();
     }
 

--- a/PartyIcons/Runtime/RoleTracker.cs
+++ b/PartyIcons/Runtime/RoleTracker.cs
@@ -308,7 +308,7 @@ public sealed class RoleTracker : IDisposable
     private void OnChatMessage(XivChatType type, uint senderid, ref SeString sender, ref SeString message,
         ref bool ishandled)
     {
-        if (type == XivChatType.Party || type == XivChatType.CrossParty || type == XivChatType.Say)
+        if (_configuration.AssignFromChat && (type == XivChatType.Party || type == XivChatType.CrossParty || type == XivChatType.Say))
         {
             string? playerName = null;
             uint? playerWorld = null;

--- a/PartyIcons/View/PlayerContextMenu.cs
+++ b/PartyIcons/View/PlayerContextMenu.cs
@@ -22,8 +22,8 @@ namespace PartyIcons.View
 
         public PlayerContextMenu(RoleTracker roleTracker, Configuration configuration, PlayerStylesheet stylesheet)
         {
-            _configuration = configuration;
             _roleTracker = roleTracker;
+            _configuration = configuration;
             _stylesheet = stylesheet;
         }
 
@@ -52,7 +52,7 @@ namespace PartyIcons.View
             var playerName = args.Text.TextValue;
             var playerWorld = args.ObjectWorld;
 
-            PluginLog.Debug($"Opening submenu for {playerName}");
+            PluginLog.Debug($"Opening menu for {playerName}");
 
             AddSuggestedRoleMenuItem(playerName, playerWorld, args);
             AddSwapRoleMenuItem(playerName, playerWorld, args);


### PR DESCRIPTION
Hey there! 

This adds a toggle to the ui to enable or disable the chat assignments (i.e. saying h1 in chat to get the h1 role.) Default is enabled, in keeping with the original function of the program. The reason for this existing is that 'mt' is also used to mean mistaken tell on NA at least, which can mess up an otherwise-good configuration.

![image](https://user-images.githubusercontent.com/696702/188286588-6180b2d8-0fb1-4458-91b1-d5059a3ca151.png)

Additionally, this removes the hardcoded debug build path. There may be further edits to make regarding this, or a better way to handle it, though.