### PR TITLE
Fix Sig Collision

### DIFF
--- a/PartyIcons/Api/PluginAddressResolver.cs
+++ b/PartyIcons/Api/PluginAddressResolver.cs
@@ -70,7 +70,7 @@ public sealed class PluginAddressResolver : BaseAddressResolver
     public IntPtr BattleCharaStorePtr;
 
     private const string BattleCharaStore_LookupBattleCharaByObjectIDSignature =
-        "E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 74 3A 48 8B C8";
+        "E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 74 3A 48 8B C8 E8 ?? ?? ?? ?? 84 C0";
 
     public IntPtr BattleCharaStore_LookupBattleCharaByObjectIDPtr;
 


### PR DESCRIPTION
As I was checking the sigs of the plugins I have the source code handy, I found this sig has multiple collisions.

Fortunately, the desired function is the first of the collisions, so it resolves properly, this PR includes a new sig that resolves these collisions.

The new sig is current as of 6.31

You could choose to ignore this PR, as the sig does correctly resolve for now, however, in the future that may no longer be the case.

![image](https://user-images.githubusercontent.com/9083275/214242304-619aad12-8fc9-4ccb-9d41-f6cc02e72fd6.png)
