### PR TITLE
Fix context menu for 6.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Dalamud.ContextMenu"]
 	path = Dalamud.ContextMenu
-	url = https://github.com/squidmade/Dalamud.ContextMenu
-	branch = net7
+	url = https://github.com/kalilistic/Dalamud.ContextMenu
+	branch = main

--- a/PartyIcons/View/PlayerContextMenu.cs
+++ b/PartyIcons/View/PlayerContextMenu.cs
@@ -41,6 +41,7 @@ namespace PartyIcons.View
         public void Dispose()
         {
             Disable();
+            _contextMenu.Dispose();
         }
         
         private void OnOpenContextMenu(GameObjectContextMenuOpenArgs args)


### PR DESCRIPTION
Updates the `Dalamud.ContextMenu` submodule to use [kalilistic/Dalamud.ContextMenu](https://github.com/kalilistic/Dalamud.ContextMenu), which is updated for 6.4 and makes the context menu work again (fixes #91).

I also added a call to `_contextMenu.Dispose()` to `PlayerContextMenu.Dispose` since `DalamudContextMenu` creates hooks which are not removed correctly unless we dispose it.